### PR TITLE
OVN split: Use the new OVN repository

### DIFF
--- a/utils/common-functions
+++ b/utils/common-functions
@@ -5,18 +5,18 @@ function install_ovs {
     sudo yum group install "Development Tools" -y
     sudo yum install python-devel python-six -y
 
-    GIT_REPO=${GIT_REPO:-https://github.com/openvswitch/ovs}
+    GIT_REPO=${GIT_REPO:-https://github.com/ovn-org/ovn}
     GIT_BRANCH=${GIT_BRANCH:-master}
 
     if [ ! -d /home/vagrant/ovs ]; then
         git clone $GIT_REPO
-        cd ovs
+        cd ovn
 
         if [[ "z$GIT_BRANCH" != "z" ]]; then
             git checkout $GIT_BRANCH
         fi
     else
-        cd ovs
+        cd ovn
     fi
 
     ./boot.sh


### PR DESCRIPTION
OVN has now been moved out of the OVS repository. This patch updates the
vagrant common code to use the new OVN repository when setting things
up.

Signed-off-by: Lucas Alvares Gomes <lucasagomes@gmail.com>