### PR TITLE
OVS+OVN: Use python3

### DIFF
--- a/utils/common-functions
+++ b/utils/common-functions
@@ -3,7 +3,8 @@ function install_ovs {
     sed -i 's/^SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config
 
     yum group install "Development Tools" -y
-    yum install python-devel python-six -y
+    yum install python3 python3-devel python3-pip -y
+    pip3 install six
     yum install net-tools tcpdump -y
     yum install epel-release -y
     yum install bmon -y


### PR DESCRIPTION
Python2 support is gone and python3 is it.
Also install python dependency needed: six.

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>