### PR TITLE
ovn-multinode-dvr: Install python3 dependencies and create br-int

### DIFF
--- a/ovn-multinode-dvr/gateway.sh
+++ b/ovn-multinode-dvr/gateway.sh
@@ -10,6 +10,10 @@ ip=${!hostname}
 /usr/share/openvswitch/scripts/ovs-ctl start --system-id=$hostname
 /usr/share/ovn/scripts/ovn-ctl start_controller
 
+# OVN controller creates the bridge but it's racey
+# with the br-set-external-id command
+ovs-vsctl add-br br-int
+
 ovs-vsctl set open . external-ids:ovn-bridge=br-int
 ovs-vsctl set open . external-ids:ovn-remote=tcp:${central}:6642
 ovs-vsctl set open . external-ids:ovn-encap-type=geneve

--- a/ovn-multinode-dvr/worker.sh
+++ b/ovn-multinode-dvr/worker.sh
@@ -10,6 +10,10 @@ ip=${!hostname}
 /usr/share/openvswitch/scripts/ovs-ctl start --system-id=$hostname
 /usr/share/ovn/scripts/ovn-ctl start_controller
 
+# OVN controller creates the bridge but it's racey
+# with the br-set-external-id command
+ovs-vsctl add-br br-int
+
 ovs-vsctl set open . external-ids:ovn-bridge=br-int
 ovs-vsctl set open . external-ids:ovn-remote=tcp:${central}:6642
 ovs-vsctl set open . external-ids:ovn-encap-type=geneve

--- a/utils/common-functions
+++ b/utils/common-functions
@@ -3,9 +3,9 @@ function install_ovs {
     sed -i 's/^SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config
 
     yum group install "Development Tools" -y
-    yum install python-devel python-six -y
     yum install net-tools tcpdump -y
     yum install epel-release -y
+    yum install python3-devel python-six openssl-devel python36-six -y
     yum install bmon -y
 
     OVS_GIT_REPO=${OVS_GIT_REPO:-https://github.com/openvswitch/ovs}


### PR DESCRIPTION
The patch adds deps for Python 3 as Python 2 is no longer supported in
OVS.

It also creates br-int before setting it in ovn-controller to avoid race
between ovn-controller creating the bridge and provisioning script
setting attributes on the bridge.